### PR TITLE
fix(atlas): submit only field with values add single select for status

### DIFF
--- a/editors/atlas-scope/editor.tsx
+++ b/editors/atlas-scope/editor.tsx
@@ -17,9 +17,13 @@ export default function Editor(props: IProps) {
   } = document;
 
   const handleSubmit = (values: Record<string, any>) => {
+    const filteredValues = Object.fromEntries(
+      Object.entries(values).filter(([_, value]) => value !== null),
+    );
+
     dispatch({
       type: "updateScopeOperation",
-      input: values,
+      input: filteredValues,
       scope: "global",
     });
   };
@@ -30,7 +34,6 @@ export default function Editor(props: IProps) {
       <EnumField
         className="mb-4"
         label="Status"
-        multiple
         name="masterStatus"
         options={[
           { value: "PLACEHOLDER", label: "PLACEHOLDER" },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@powerhousedao/codegen": "^0.16.0",
     "@powerhousedao/connect": "develop",
     "@powerhousedao/scalars": "^1.8.0",
-    "@powerhousedao/design-system":"1.9.1-canary.100",
+    "@powerhousedao/design-system":"1.9.1-canary.104",
     "@powerhousedao/ph-cli": "^0.11.0",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^22.7.3",


### PR DESCRIPTION
## Ticket
https://trello.com/c/m5R6RQbp/786-atlas-scope-v1

##Description
- Only submit the field with values
- Add a single select for status and change the label


ScreenShots
<img width="1319" alt="new-change" src="https://github.com/user-attachments/assets/39f8b769-ea69-4532-ab92-14dfc66ea02d" />
<img width="1720" alt="Status-single-select" src="https://github.com/user-attachments/assets/f7f0f2ff-bf8a-4c86-81b0-8ee7e975e581" />

